### PR TITLE
Incorporate user feedback (database permissions and connection URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,49 @@ Resources created by this bundle that can be connected to other bundles.
           - **`cluster_id`** *(string)*
           - **`project_id`** *(string)*
   - **`specs`** *(object)*
+    - **`aws`** *(object)*: .
+      - **`region`** *(string)*: AWS Region to provision in.
+
+        Examples:
+        ```json
+        "us-west-2"
+        ```
+
+    - **`azure`** *(object)*: .
+      - **`region`** *(string)*: Select the Azure region you'd like to provision your resources in.
+    - **`gcp`** *(object)*: .
+      - **`project`** *(string)*
+      - **`region`** *(string)*: The GCP region to provision resources in.
+
+        Examples:
+        ```json
+        "us-east1"
+        ```
+
+        ```json
+        "us-east4"
+        ```
+
+        ```json
+        "us-west1"
+        ```
+
+        ```json
+        "us-west2"
+        ```
+
+        ```json
+        "us-west3"
+        ```
+
+        ```json
+        "us-west4"
+        ```
+
+        ```json
+        "us-central1"
+        ```
+
     - **`mongo`** *(object)*: Informs downstream bundles of Mongo specific data. Cannot contain additional properties.
       - **`version`** *(string)*: Currently deployed Mongo version.
 <!-- ARTIFACTS:END -->

--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -6,7 +6,7 @@ locals {
   data_authentication = {
     username = module.mongodb.username
     password = module.mongodb.password
-    hostname = module.mongodb.cluster_srv_connection_url
+    hostname = trimprefix(module.mongodb.cluster_srv_connection_url, "mongodb+srv://")
     port     = 27017
   }
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "mongodb" {
-  source = "github.com/massdriver-cloud/terraform-modules//mongodbatlas/cluster-aws?ref=efb8551"
+  source = "github.com/massdriver-cloud/terraform-modules//mongodbatlas/cluster-aws?ref=febb095"
 
   mongodb_organization_id        = var.mongodbatlas_creds.organization_id
   name                           = var.md_metadata.name_prefix

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "mongodb" {
-  source = "github.com/massdriver-cloud/terraform-modules//mongodbatlas/cluster-aws?ref=febb095"
+  source = "github.com/massdriver-cloud/terraform-modules//mongodbatlas/cluster-aws?ref=df15421"
 
   mongodb_organization_id        = var.mongodbatlas_creds.organization_id
   name                           = var.md_metadata.name_prefix


### PR DESCRIPTION
This PR incorporates two points of user feedback:
1. Updates the module to a new version that adds an additional `readWrite@` role to the database user
2. Trims the `mongodb+srv://` prefix from the hostname, making it much easier for users to compose their own connection strings via environment variables.